### PR TITLE
Remove C4 Specific Features from Preprocessing

### DIFF
--- a/1 Preprocess/Continuous Data/1.0.0 Preprocess.ipynb
+++ b/1 Preprocess/Continuous Data/1.0.0 Preprocess.ipynb
@@ -2,6 +2,13 @@
   "cells": [
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": []
+    },
+    {
+      "cell_type": "code",
       "execution_count": 42,
       "metadata": {
         "tags": [],
@@ -243,7 +250,12 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "# Final Dataset Cleaning"
+        "# Final Dataset Cleaning\n",
+        "\n",
+        "## These are the Butanol required Features:\n",
+        "\n",
+        "### Muted for Decanol Development: \n",
+        "Perhaps consider not returning here to run the page. Instead create a function from this page and call it when needed to re-\"preprocess.\" The re-Preprocess ensure minimal data loss due to drops from other features that are not part of the final feature selection."
       ]
     },
     {
@@ -252,15 +264,15 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "ids_to_keep = ['AS73425-3%Al', 'AS74550-4ButanolPP',\n",
-        "                    'FC55569', 'DI55152', 'TC55552',\n",
-        "                    'FC55003', 'LC55555', 'FFC55553',\n",
-        "                    'FFC55555', 'TI55021',\n",
-        "                    'PI55004', 'FC55552',\n",
+        "# ids_to_keep = ['AS73425-3%Al', 'AS74550-4ButanolPP',\n",
+        "#                     'FC55569', 'DI55152', 'TC55552',\n",
+        "#                     'FC55003', 'LC55555', 'FFC55553',\n",
+        "#                     'FFC55555', 'TI55021',\n",
+        "#                     'PI55004', 'FC55552',\n",
         "                                 \n",
-        "               'AS74550-25%C2OH', 'AS74550-25%nC4OH',\n",
-        "               'AS74550-25%H2O', 'AS74550-10%M-Value', \n",
-        "               'AS74550-5%pH', 'AS74550-5%NH4OH'\n",
+        "#                'AS74550-25%C2OH', 'AS74550-25%nC4OH',\n",
+        "#                'AS74550-25%H2O', 'AS74550-10%M-Value', \n",
+        "#                'AS74550-5%pH', 'AS74550-5%NH4OH'\n",
         "               ]\n",
         "   # 'AS74550-4DecanolPP': 'Decanol',, 'AS74550-5ppmNa2O', 'AS74550-25%nC6OH' 'TC55555',\n",
         "\n",


### PR DESCRIPTION
These changes remove the variables specific to C4 at preprocessing. Better coding quality is to implement specific iterations of preprocessing as needed, IMhumbleO.